### PR TITLE
Feature/fix tmc22xx build

### DIFF
--- a/drivers/stepper/adi_tmc/tmc22xx.c
+++ b/drivers/stepper/adi_tmc/tmc22xx.c
@@ -19,11 +19,10 @@ struct tmc22xx_config {
 };
 
 struct tmc22xx_data {
-	struct step_dir_stepper_common_data common;
 	enum stepper_micro_step_resolution resolution;
 };
 
-STEP_DIR_STEPPER_STRUCT_CHECK(struct tmc22xx_config, struct tmc22xx_data);
+STEP_DIR_STEPPER_STRUCT_CHECK(struct tmc22xx_config);
 
 static int tmc22xx_stepper_enable(const struct device *dev)
 {
@@ -176,7 +175,6 @@ static DEVICE_API(stepper, tmc22xx_stepper_api) = {
 		(.msx_pins = tmc22xx_stepper_msx_pins_##inst))					   \
 	};                                                                                         \
 	static struct tmc22xx_data tmc22xx_data_##inst = {                                         \
-		.common = STEP_DIR_STEPPER_DT_INST_COMMON_DATA_INIT(inst),                         \
 		.resolution = DT_INST_PROP(inst, micro_step_res),                                  \
 	};                                                                                         \
 	DEVICE_DT_INST_DEFINE(inst, tmc22xx_stepper_init, NULL, &tmc22xx_data_##inst,              \

--- a/drivers/stepper/adi_tmc/tmc22xx.c
+++ b/drivers/stepper/adi_tmc/tmc22xx.c
@@ -30,7 +30,7 @@ static int tmc22xx_stepper_enable(const struct device *dev)
 	const struct tmc22xx_config *config = dev->config;
 
 	LOG_DBG("Enabling Stepper motor controller %s", dev->name);
-	return gpio_pin_set_dt(&config->enable_pin, 1);
+	return gpio_pin_set_dt(&config->enable_pin, 0);
 }
 
 static int tmc22xx_stepper_disable(const struct device *dev)
@@ -38,7 +38,7 @@ static int tmc22xx_stepper_disable(const struct device *dev)
 	const struct tmc22xx_config *config = dev->config;
 
 	LOG_DBG("Disabling Stepper motor controller %s", dev->name);
-	return gpio_pin_set_dt(&config->enable_pin, 0);
+	return gpio_pin_set_dt(&config->enable_pin, 1);
 }
 
 static int tmc22xx_stepper_set_micro_step_res(const struct device *dev,

--- a/drivers/stepper/step_dir/step_dir_stepper_common.h
+++ b/drivers/stepper/step_dir/step_dir_stepper_common.h
@@ -56,13 +56,10 @@ struct step_dir_stepper_common_config {
  * @brief Validate the offset of the common data structures.
  *
  * @param config Name of the config structure.
- * @param data Name of the data structure.
  */
-#define STEP_DIR_STEPPER_STRUCT_CHECK(config, data)                                                \
+#define STEP_DIR_STEPPER_STRUCT_CHECK(config)                                                      \
 	BUILD_ASSERT(offsetof(config, common) == 0,                                                \
-		     "struct step_dir_stepper_common_config must be placed first");                \
-	BUILD_ASSERT(offsetof(data, common) == 0,                                                  \
-		     "struct step_dir_stepper_common_data must be placed first");
+		     "struct step_dir_stepper_common_config must be placed first");
 
 /**
  * @brief Common function to initialize a step direction stepper device at init time.


### PR DESCRIPTION
- inverted en-pin logic for tmc2209 based on the datasheet (HIGH: disable, LOW: enable)
- removed references to deleted structs in tmc22xx device driver